### PR TITLE
Rewrite

### DIFF
--- a/evafast.conf
+++ b/evafast.conf
@@ -33,5 +33,6 @@ show_seek=yes
 # Look ahead for smoother transition when subs_speed_cap is set
 subs_lookahead=yes
 
-# Symbol prepended to the osd message
+# Symbols prepended to the osd message
 osd_symbol={\fnmpv-osd-symbols} {\r}
+osd_rewind={\fnmpv-osd-symbols} {\r}

--- a/evafast.conf
+++ b/evafast.conf
@@ -32,3 +32,6 @@ show_seek=yes
 
 # Look ahead for smoother transition when subs_speed_cap is set
 subs_lookahead=yes
+
+# Symbol prepended to the osd message
+osd_symbol={\fnmpv-osd-symbols} {\r}

--- a/evafast.conf
+++ b/evafast.conf
@@ -1,4 +1,4 @@
-# How far to jump on press
+# How far to jump on press, set to 0 to disable seeking and force fastforward
 seek_distance=5
 
 # Playback speed modifier, applied once every speed_interval until cap is reached
@@ -11,7 +11,7 @@ speed_interval=0.05
 # Playback speed cap
 speed_cap=2
 
-# Playback speed cap when subtitles are displayed, 'no' for same as speed_cap
+# Playback speed cap when subtitles are displayed, ignored when equal to speed_cap
 subs_speed_cap=1.6
 
 # Multiply current speed by modifier before adjustment (exponential speedup)
@@ -24,8 +24,11 @@ show_speed=yes
 # Show current speed on the osd when toggled (or flash speed if using uosc)
 show_speed_toggled=yes
 
+# Show current speed on the osd when speeding up towards a target time (or flash speed if using uosc)
+show_speed_target=no
+
 # Show seek actions on the osd (or flash timeline if using uosc)
 show_seek=yes
 
 # Look ahead for smoother transition when subs_speed_cap is set
-lookahead=no
+subs_lookahead=yes

--- a/evafast.lua
+++ b/evafast.lua
@@ -237,7 +237,7 @@ local function adjust_speed()
         end
     end
 
-    if math.floor(target_speed * 1000) == math.floor(current_speed * 1000) then
+    if math.floor(target_speed * 1000 + 0.5) == math.floor(current_speed * 1000 + 0.5) then
         if forced_slowdown or (not toggled and (not speedup or options.subs_speed_cap == options.speed_cap or (not has_subtitle and not speedup_target))) then
             speed_timer:kill()
             toggled_display = true

--- a/evafast.lua
+++ b/evafast.lua
@@ -165,7 +165,7 @@ local function adjust_speed()
                 end
                 if next_sub_at >= current_time then
                     local time_for_correction = speed_transition(current_speed, options.subs_speed_cap)
-                    if (time_for_correction * current_speed + current_time) > next_sub_at then
+                    if (time_for_correction + current_time) > next_sub_at then
                         target_speed = options.subs_speed_cap
                     end
                 end
@@ -177,7 +177,7 @@ local function adjust_speed()
                 evafast_slowdown()
             else
                 local time_for_correction = speed_transition(current_speed, original_speed)
-                if (time_for_correction * current_speed + current_time) > speedup_target then
+                if (time_for_correction + current_time) > speedup_target then
                     forced_slowdown = true
                     speedup = false
                     target_speed = original_speed

--- a/evafast.lua
+++ b/evafast.lua
@@ -48,7 +48,7 @@ local options = {
 }
 
 mp.options = require "mp.options"
-mp.options.read_options(options, "evafast")
+mp.options.read_options(options, "evafast", function() end)
 
 local uosc_available = false
 local has_subtitle = true
@@ -370,19 +370,6 @@ end)
 
 mp.register_script_message("get-version", function(script)
     mp.commandv("script-message-to", script, "evafast-version", "2.0")
-end)
-
-mp.register_script_message("set-option", function(option, value)
-    if options[option] == nil then return end
-    value_type = type(options[option])
-
-    if value_type == "number" then
-        options[option] = tonumber(value) or options[option]
-    elseif value_type == "boolean" then
-        options[option] = ((tonumber(value) or 0) > 0)
-    else
-        options[option] = value
-    end
 end)
 
 mp.add_key_binding("RIGHT", "evafast", evafast, {repeatable = true, complex = true})

--- a/evafast.lua
+++ b/evafast.lua
@@ -51,6 +51,7 @@ mp.options.read_options(options, "evafast")
 
 local uosc_available = false
 local has_subtitle = true
+local has_text_subtitle = false
 local speedup_target = nil
 local toggled_display = true
 local toggled = false
@@ -189,7 +190,15 @@ local function adjust_speed()
         target_speed = options.speed_cap
 
         if has_subtitle and target_speed ~= options.subs_speed_cap then
-            if mp.get_property("sub-start") ~= nil then
+            local sub_displayed
+
+            if has_text_subtitle then
+                sub_displayed = mp.get_property("sub-text", "") ~= ""
+            else
+                sub_displayed = mp.get_property("sub-start") ~= nil
+            end
+
+            if sub_displayed then
                 target_speed = options.subs_speed_cap
             end
 
@@ -315,6 +324,10 @@ end
 
 mp.observe_property("duration", "native", function(prop, val)
     file_duration = val or 0
+end)
+
+mp.observe_property("current-tracks/sub/codec", "native", function(prop, val)
+    has_text_subtitle = val ~= nil and val ~= "hdmv_pgs_subtitle" and val ~= "dvd_subtitle" and val ~= "dvb_subtitle"
 end)
 
 mp.observe_property("sid", "native", function(prop, val)

--- a/evafast.lua
+++ b/evafast.lua
@@ -126,6 +126,9 @@ local function flash_state(current_speed, display, forced)
         if uosc_show then
             mp.command("script-binding uosc/flash-speed")
         elseif osd_show then
+            if current_speed == true then
+                current_speed = mp.get_property_number("speed", 1)
+            end
             mp.osd_message(string.format("▶▶ x%.1f", current_speed))
         end
     elseif not current_speed and options.show_seek then
@@ -384,7 +387,7 @@ end)
 
 mp.add_key_binding("RIGHT", "evafast", evafast, {repeatable = true, complex = true})
 mp.add_key_binding(nil, "evafast-rewind", evafast_rewind, {repeatable = true, complex = true})
-mp.add_key_binding(nil, "flash-speed", function() flash_state(mp.get_property_number("speed", 1), nil, true) end)
+mp.add_key_binding(nil, "flash-speed", function() flash_state(true, nil, true) end)
 mp.add_key_binding(nil, "speedup", evafast_speedup)
 mp.add_key_binding(nil, "slowdown", evafast_slowdown)
 mp.add_key_binding(nil, "toggle", evafast_toggle)

--- a/evafast.lua
+++ b/evafast.lua
@@ -208,9 +208,7 @@ local function adjust_speed()
 
             if sub_displayed then
                 target_speed = options.subs_speed_cap
-            end
-
-            if options.subs_lookahead then
+            elseif options.subs_lookahead then
                 if next_sub_at < current_time and next_sub_at ~= -2 then
                     next_sub_at = next_sub(current_time)
                 end

--- a/evafast.lua
+++ b/evafast.lua
@@ -8,7 +8,7 @@
 -- Adjust --input-ar-delay to define when to start fastforwarding.
 -- Define --hr-seek if you want accurate seeking.
 -- If you just want a nicer fastforward.lua without hybrid key behavior, set seek_distance to 0.
--- Consider setting --sub-filter-regex=^\s*$ (or --sub-filter-jsre on Windows) to ignore empty lines.
+-- Consider setting --sub-filter-regex="\`\s*\'" (on Linux) to ignore empty lines.
 
 local options = {
     -- How far to jump on press, set to 0 to disable seeking and force fastforward

--- a/evafast.lua
+++ b/evafast.lua
@@ -131,7 +131,7 @@ local function ensure_timer(reset)
 end
 
 local function evafast_speedup(toggle)
-    if not toggled and not speed_timer:is_enabled() then
+    if not toggled and not speedup_target and not speed_timer:is_enabled() then
         original_speed = mp.get_property_number("speed", 1)
     end
 
@@ -206,7 +206,7 @@ local function adjust_speed()
     end
 
     if math.floor(target_speed * 1000) == math.floor(current_speed * 1000) then
-        if forced_slowdown or (not toggled and (not speedup or options.subs_speed_cap == options.speed_cap or not has_subtitle)) then
+        if forced_slowdown or (not toggled and (not speedup or options.subs_speed_cap == options.speed_cap or (not has_subtitle and not speedup_target))) then
             speed_timer:kill()
             toggled_display = true
             if speedup_target ~= nil then
@@ -251,7 +251,7 @@ local function evafast(keypress, rewind)
     end
     if keypress["event"] == "down" then
         if not speed_timer:is_enabled() then
-            if not toggled then
+            if not toggled and not speedup_target then
                 original_speed = mp.get_property_number("speed", 1)
             end
             flash_state(nil, "osd")
@@ -265,7 +265,7 @@ local function evafast(keypress, rewind)
     end
 
     if keypress["event"] == "press" or keypress["event"] == "up" and last_key_state ~= "repeat" then
-        if not toggled then
+        if not toggled and not speedup_target then
             speed_timer:kill()
             mp.set_property("speed", original_speed)
         end
@@ -285,7 +285,7 @@ local function evafast(keypress, rewind)
             mp.set_property("play-dir", "-")
             rewinding = true
         end
-    elseif keypress["event"] == "up" and not toggled then
+    elseif keypress["event"] == "up" and not toggled and not speedup_target then
         evafast_slowdown(true)
         ensure_timer(true)
     end

--- a/evafast.lua
+++ b/evafast.lua
@@ -156,14 +156,16 @@ local function adjust_speed()
     if speedup then
         target_speed = options.speed_cap
 
-        if has_subtitle and options.subs_speed_cap ~= options.speed_cap then
+        if has_subtitle then
             if mp.get_property("sub-start") ~= nil then
                 target_speed = options.subs_speed_cap
-            elseif options.subs_lookahead then
+            end
+
+            if options.subs_lookahead then
                 if next_sub_at < current_time then
                     next_sub_at = next_sub(current_time)
                 end
-                if next_sub_at >= current_time then
+                if options.subs_speed_cap ~= target_speed and next_sub_at > current_time then
                     local time_for_correction = speed_transition(current_speed, options.subs_speed_cap)
                     if (time_for_correction + current_time) > next_sub_at then
                         target_speed = options.subs_speed_cap

--- a/evafast.lua
+++ b/evafast.lua
@@ -58,29 +58,14 @@ local speedup = false
 local original_speed = 1
 local next_sub_at = -1
 
-local function speed_transition(test_speed, target_speed)
-    local speed_correction = 0
-    local time_for_correction = 0
+local function speed_transition(current_speed, target_speed)
+    local speed_correction = current_speed >= target_speed and options.speed_decrease or options.speed_increase
 
-    while test_speed ~= target_speed do
-        time_for_correction = time_for_correction + options.speed_interval
-
-        if options.multiply_modifier then
-            speed_correction = test_speed * options.speed_increase
-        else
-            speed_correction = options.speed_increase
-        end
-
-        if test_speed > target_speed then
-            test_speed = math.max(test_speed - speed_correction, 1)
-        else
-            test_speed = math.min(test_speed + speed_correction, target_speed)
-        end
-
-        if test_speed == 1 then break end
+    if speed_correction == 0 then
+        return 0
     end
 
-    return time_for_correction
+    return math.ceil(math.abs(target_speed - current_speed) / speed_correction) * options.speed_interval
 end
 
 local function next_sub(current_time)

--- a/evafast.lua
+++ b/evafast.lua
@@ -96,31 +96,24 @@ local function next_sub(current_time)
 end
 
 local function flash_speed(current_speed, display, forced)
-    if current_speed then
-        if ((toggled or not speedup) and ((options.show_speed_toggled and not speedup_target) or (options.show_speed_target and speedup_target)))
-            or (not toggled and options.show_speed and toggled_display)
-            or forced then
-            if uosc_available then
-                if not display or display == "uosc" then
-                    mp.command("script-binding uosc/flash-speed")
-                end
-            elseif current_speed then
-                if not display or display == "osd" then
-                    mp.osd_message(string.format("▶▶ x%.1f", current_speed))
-                end
-            end
+    local uosc_show = uosc_available and (display == nil or display == "uosc")
+    local osd_show = not uosc_available and (display == nil or display == "osd")
+
+    local show_special = (options.show_speed_toggled and not speedup_target) or (options.show_speed_target and speedup_target)
+    local show_toggled = (toggled or not speedup) and show_special
+    local show_regular = not toggled and options.show_speed and toggled_display
+
+    if current_speed and (show_toggled or show_regular or forced) then
+        if uosc_show then
+            mp.command("script-binding uosc/flash-speed")
+        elseif osd_show then
+            mp.osd_message(string.format("▶▶ x%.1f", current_speed))
         end
-    else
-        if options.show_seek then
-            if uosc_available then
-                if not display or display == "uosc" then
-                    mp.command("script-binding uosc/flash-timeline")
-                end
-            else
-                if not display or display == "osd" then
-                    mp.osd_message("▶▶")
-                end
-            end
+    elseif options.show_seek and not current_speed then
+        if uosc_show then
+            mp.command("script-binding uosc/flash-timeline")
+        elseif osd_show then
+            mp.osd_message("▶▶")
         end
     end
 end

--- a/evafast.lua
+++ b/evafast.lua
@@ -283,16 +283,20 @@ mp.observe_property("duration", "native", function(prop, val)
     file_duration = val or 0
 end)
 
-mp.observe_property("sub-start", "native", function(prop, val)
-    next_sub_at = -1
-end)
-
 mp.observe_property("sid", "native", function(prop, val)
     has_subtitle = (val or 0) ~= 0
     next_sub_at = -1
 end)
 
+mp.observe_property("sub-start", "native", function(prop, val)
+    next_sub_at = -1
+end)
+
 mp.register_event("file-loaded", function()
+    next_sub_at = -1
+end)
+
+mp.register_event("seek", function()
     next_sub_at = -1
 end)
 

--- a/evafast.lua
+++ b/evafast.lua
@@ -213,6 +213,10 @@ local function adjust_speed()
                 evafast_slowdown()
             end
             speedup_target = nil
+            if rewinding then
+                mp.set_property("play-dir", "+")
+                rewinding = false
+            end
         end
         return
     end
@@ -241,6 +245,10 @@ speed_timer = mp.add_periodic_timer(100, adjust_speed)
 speed_timer:kill()
 
 local function evafast(keypress, rewind)
+    if rewinding and not rewind then
+        rewinding = false
+        mp.set_property("play-dir", "+")
+    end
     if keypress["event"] == "down" then
         if not speed_timer:is_enabled() then
             if not toggled then
@@ -263,10 +271,20 @@ local function evafast(keypress, rewind)
         end
         flash_state()
         ensure_timer()
-        mp.commandv("seek", options.seek_distance)
+        if rewind then
+            mp.commandv("seek", -options.seek_distance)
+            mp.set_property("play-dir", "+")
+            rewinding = false
+        else
+            mp.commandv("seek", options.seek_distance)
+        end
     elseif keypress["event"] == "repeat" and last_key_state ~= "repeat" then
         speedup = true
         ensure_timer()
+        if rewind then
+            mp.set_property("play-dir", "-")
+            rewinding = true
+        end
     elseif keypress["event"] == "up" and not toggled then
         evafast_slowdown(true)
         ensure_timer(true)

--- a/evafast.lua
+++ b/evafast.lua
@@ -151,12 +151,13 @@ local function evafast_slowdown(display)
     end
     toggled = false
     speedup = false
+
+    ensure_timer()
 end
 
 local function evafast_toggle()
     if speedup then
         evafast_slowdown()
-        ensure_timer()
     else
         evafast_speedup(true)
     end

--- a/evafast.lua
+++ b/evafast.lua
@@ -166,6 +166,9 @@ local function evafast_slowdown(display)
 end
 
 local function evafast_toggle()
+    if toggled_rewind then
+        mp.set_property("play-dir", "+")
+    end
     toggled_rewind = false
     if speedup then
         evafast_slowdown()

--- a/evafast.lua
+++ b/evafast.lua
@@ -46,8 +46,9 @@ local options = {
     -- Look ahead for smoother transition when subs_speed_cap is set
     subs_lookahead = true,
 
-    -- Symbol prepended to the osd message
-    osd_symbol = "{\\fnmpv-osd-symbols} {\\r}"
+    -- Symbols prepended to the osd message
+    osd_symbol = "{\\fnmpv-osd-symbols} {\\r}",
+    osd_rewind = "{\\fnmpv-osd-symbols} {\\r}"
 }
 
 mp.options = require "mp.options"
@@ -66,6 +67,7 @@ local rewinding = false
 local forced_slowdown = false
 local file_duration = 0
 local last_key_state = "up"
+local was_rewinding = false
 
 local ass_start = mp.get_property_osd("osd-ass-cc/0")
 local ass_stop = mp.get_property_osd("osd-ass-cc/1")
@@ -135,13 +137,13 @@ local function flash_state(current_speed, display, forced)
             if current_speed == true then
                 current_speed = mp.get_property_number("speed", 1)
             end
-            mp.osd_message(ass_start .. options.osd_symbol .. ass_stop .. string.format("x%.1f", current_speed))
+            mp.osd_message(ass_start .. (was_rewinding and options.osd_rewind or options.osd_symbol) .. ass_stop .. string.format("x%.1f", current_speed))
         end
     elseif not current_speed and options.show_seek then
         if uosc_show then
             mp.command("script-binding uosc/flash-timeline")
         elseif osd_show then
-            mp.osd_message(ass_start .. options.osd_symbol)
+            mp.osd_message(ass_start .. (was_rewinding and options.osd_rewind or options.osd_symbol))
         end
     end
 end
@@ -276,9 +278,14 @@ speed_timer = mp.add_periodic_timer(100, adjust_speed)
 speed_timer:kill()
 
 local function evafast(keypress, rewind)
+    was_rewinding = false
     if rewinding and not toggled_rewind and (not rewind or (keypress["event"] == "up" and last_key_state ~= "down")) then
         rewinding = false
+        was_rewinding = true
         mp.set_property("play-dir", "+")
+    end
+    if rewind then
+        was_rewinding = true
     end
 
     if keypress["event"] == "down" then

--- a/evafast.lua
+++ b/evafast.lua
@@ -8,6 +8,7 @@
 -- Adjust --input-ar-delay to define when to start fastforwarding.
 -- Define --hr-seek if you want accurate seeking.
 -- If you just want a nicer fastforward.lua without hybrid key behavior, set seek_distance to 0.
+-- Consider setting --sub-filter-regex=^\s*$ (or --sub-filter-jsre on Windows) to ignore empty lines.
 
 local options = {
     -- How far to jump on press, set to 0 to disable seeking and force fastforward
@@ -51,7 +52,6 @@ mp.options.read_options(options, "evafast")
 
 local uosc_available = false
 local has_subtitle = true
-local has_text_subtitle = false
 local speedup_target = nil
 local toggled_display = true
 local toggled = false
@@ -198,13 +198,7 @@ local function adjust_speed()
         target_speed = options.speed_cap
 
         if has_subtitle and target_speed ~= options.subs_speed_cap then
-            local sub_displayed
-
-            if has_text_subtitle then
-                sub_displayed = mp.get_property("sub-text", "") ~= ""
-            else
-                sub_displayed = mp.get_property("sub-start") ~= nil
-            end
+            local sub_displayed = mp.get_property("sub-start") ~= nil
 
             if sub_displayed then
                 target_speed = options.subs_speed_cap
@@ -330,10 +324,6 @@ end
 
 mp.observe_property("duration", "native", function(prop, val)
     file_duration = val or 0
-end)
-
-mp.observe_property("current-tracks/sub/codec", "native", function(prop, val)
-    has_text_subtitle = val ~= nil and val ~= "hdmv_pgs_subtitle" and val ~= "dvd_subtitle" and val ~= "dvb_subtitle"
 end)
 
 mp.observe_property("sid", "native", function(prop, val)

--- a/evafast.lua
+++ b/evafast.lua
@@ -44,7 +44,10 @@ local options = {
     show_seek = true,
 
     -- Look ahead for smoother transition when subs_speed_cap is set
-    subs_lookahead = true
+    subs_lookahead = true,
+
+    -- Symbol prepended to the osd message
+    osd_symbol = "{\\fnmpv-osd-symbols} {\\r}"
 }
 
 mp.options = require "mp.options"
@@ -63,6 +66,9 @@ local rewinding = false
 local forced_slowdown = false
 local file_duration = 0
 local last_key_state = "up"
+
+local ass_start = mp.get_property_osd("osd-ass-cc/0")
+local ass_stop = mp.get_property_osd("osd-ass-cc/1")
 
 local function speed_transition(current_speed, target_speed)
     local speed_correction = current_speed >= target_speed and -options.speed_decrease or options.speed_increase
@@ -129,13 +135,13 @@ local function flash_state(current_speed, display, forced)
             if current_speed == true then
                 current_speed = mp.get_property_number("speed", 1)
             end
-            mp.osd_message(string.format("▶▶ x%.1f", current_speed))
+            mp.osd_message(ass_start .. options.osd_symbol .. ass_stop .. string.format("x%.1f", current_speed))
         end
     elseif not current_speed and options.show_seek then
         if uosc_show then
             mp.command("script-binding uosc/flash-timeline")
         elseif osd_show then
-            mp.osd_message("▶▶")
+            mp.osd_message(ass_start .. options.osd_symbol)
         end
     end
 end

--- a/evafast.lua
+++ b/evafast.lua
@@ -72,7 +72,12 @@ local function speed_transition(current_speed, target_speed)
 
     while adjusted_speed ~= target_speed do
         time_for_correction = time_for_correction + options.speed_interval * adjusted_speed
-        adjusted_speed = adjusted_speed + speed_correction
+
+        if options.multiply_modifier then
+            adjusted_speed = adjusted_speed + adjusted_speed * speed_correction
+        else
+            adjusted_speed = adjusted_speed + speed_correction
+        end
 
         if (current_speed < target_speed and adjusted_speed > target_speed) or (current_speed > target_speed and adjusted_speed < target_speed) then
             adjusted_speed = target_speed

--- a/evafast.lua
+++ b/evafast.lua
@@ -99,17 +99,17 @@ local function flash_speed(current_speed, display, forced)
     local uosc_show = uosc_available and (display == nil or display == "uosc")
     local osd_show = not uosc_available and (display == nil or display == "osd")
 
-    local show_special = (options.show_speed_toggled and not speedup_target) or (options.show_speed_target and speedup_target)
-    local show_toggled = (toggled or not speedup) and show_special
-    local show_regular = not toggled and options.show_speed and toggled_display
+    local show_special = (not speedup_target and options.show_speed_toggled) or (speedup_target and options.show_speed_target)
+    local show_toggled = show_special and (toggled or not speedup)
+    local show_regular = not toggled and toggled_display and options.show_speed
 
-    if current_speed and (show_toggled or show_regular or forced) then
+    if current_speed and (show_regular or show_toggled or forced) then
         if uosc_show then
             mp.command("script-binding uosc/flash-speed")
         elseif osd_show then
             mp.osd_message(string.format("▶▶ x%.1f", current_speed))
         end
-    elseif options.show_seek and not current_speed then
+    elseif not current_speed and options.show_seek then
         if uosc_show then
             mp.command("script-binding uosc/flash-timeline")
         elseif osd_show then


### PR DESCRIPTION
Should make it easier to add new features. Much less dumb global state management required.

Finally closes #2. Closes #5. I've realized there probably is no downside to restoring original speed, didn't make an option to disable it.
Closes #1 through a script message to be used for input.conf commands like `; script-message-to evafast set-option speed_cap 5`.
Closes #7.

All current functionality and dumb QoL stuff I could remember has been reimplemented.  
~~It's not impossible I've missed edge cases.~~ I have missed edge cases.

`speedup-target` is barely tested, but seems to work fine.  
Subtitle lookahead should be slightly more accurate.

To do:
- [x] Remove hardcoded `1`'s in `speed_transition()`, maybe use math instead of dumb recursion
- [x] Better caching/clearing of `next_sub_at`
- [x] Better displayed subtitle heuristic, check `sub-start` for image-based subs and `sub-text` for text-based subs
- [x] Flatten if pyramids in `flash_speed()`
- [ ] Redo #4
- [ ] Steal `dropOnAVdesync` from speed-transition.lua
- [ ] Warn about low `demuxer-readahead-secs` and `cache-secs` (depending on current settings and/or automatically set them)
- [ ] Document script-bindings better
- [ ] Customizable seek command #6
- [ ] Reset speed when seeking past speedup-target
- [x] Rewinding while toggled
- [x] Rewind toggle binding
- [ ] Subtitle lookbehind when rewinding
- [ ] Solve speed fluctuation at gap between subtitles in slowdown range (including when the player is paused)
- [ ] Restore original play-dir, if the user was playing a video backwards for whatever reason
- [x] Releasing speedup key after reaching full speed on files without subtitles shouldn't seek
- [ ] (?) Simulate repeat to allow for mouse input #3
- [ ] Ability to use osd display even when the user has uosc
- [ ] Holding down a toggle key shouldn't make speed flicker
- [x] Don't fetch next sub for every single line in frame-by-frame typesetting