### PR TITLE
Round values in timer target speed check

### DIFF
--- a/evafast.lua
+++ b/evafast.lua
@@ -237,7 +237,7 @@ local function adjust_speed()
         end
     end
 
-    if math.floor(target_speed * 1000) == math.floor(current_speed * 1000) then
+    if math.floor(target_speed * 1000 + 0.5) == math.floor(current_speed * 1000 + 0.5) then
         if forced_slowdown or (not toggled and (not speedup or options.subs_speed_cap == options.speed_cap or (not has_subtitle and not speedup_target))) then
             speed_timer:kill()
             toggled_display = true


### PR DESCRIPTION
math.floor() can result in one value being off by 1 because one was just barely below the whole integer while the other one was not. (floating point numbers \o/)
Adding 0.5 for actual rounding avoids that problem.

Closes #9